### PR TITLE
Remove code that handles -sme option now that it is automatic.

### DIFF
--- a/mooltipy/utilities/mpdata.py
+++ b/mooltipy/utilities/mpdata.py
@@ -179,8 +179,7 @@ def del_context(mooltipass, args):
     if not mooltipass.set_data_context(args.context):
         raise RuntimeError('That context ({}) does not exist.'.format(args.context))
 
-    if args.skip_mgmt_enter == False:
-        mooltipass.start_memory_management()
+    mooltipass.start_memory_management()
 
     for pnode in mooltipass.parent_nodes('data'):
         if pnode.service_name == args.context:
@@ -191,8 +190,7 @@ def del_context(mooltipass, args):
 
 def list_context(mooltipass, args):
     """Display a list of data contexts."""
-    if args.skip_mgmt_enter == False:
-        mooltipass.start_memory_management()
+    mooltipass.start_memory_management()
     s = '{:<40}{:<40}\n'.format('Context:','Approximate Size:')
     s += '{:<40}{:<40}\n'.format('--------','----------------')
     for pnode in mooltipass.parent_nodes('data'):

--- a/mooltipy/utilities/mpfavorites.py
+++ b/mooltipy/utilities/mpfavorites.py
@@ -197,8 +197,7 @@ def main():
         time.sleep(1)
     quiet_bool = False
 
-    if args.skip_mgmt_enter == False:
-        mooltipass.start_memory_management()
+    mooltipass.start_memory_management()
     command_handlers[args.command](mooltipass, args)
     if args.skip_mgmt_exit == False:
         mooltipass.end_memory_management()

--- a/mooltipy/utilities/mplogin.py
+++ b/mooltipy/utilities/mplogin.py
@@ -213,8 +213,7 @@ def get_context(mooltipass, args):
 
 def list_context(mooltipass, args):
     """List login contexts"""
-    if args.skip_mgmt_enter == False:
-        mooltipass.start_memory_management()
+    mooltipass.start_memory_management()
 
     s = '{:<40}{:<40}\n'.format('Context:','Login(s):')
     s += '{:<40}{:<40}\n'.format('--------','---------')
@@ -292,8 +291,7 @@ def del_context(mooltipass, args):
     if not mooltipass.set_context(args.context):
         raise RuntimeError('That context ({}) does not exist.'.format(args.context))
 
-    if args.skip_mgmt_enter == False:
-        mooltipass.start_memory_management()
+    mooltipass.start_memory_management()
 
     for pnode in mooltipass.parent_nodes('login'):
         if pnode.service_name == args.context:


### PR DESCRIPTION
Now that entering memory management mode will automatically be skipped
if the Mooltipy is already in memory management mode, there is no need
for the code to skip mooltipass.start_memory_management().  This
change does not remove the parsing of the -sme option though in case
it is desired to leave it for backwards compatibility.